### PR TITLE
fix: amend string bondary bugs in gitleaks-original-encoded-secrets

### DIFF
--- a/gitleaks-original-encoded-secrets
+++ b/gitleaks-original-encoded-secrets
@@ -22,11 +22,10 @@ def extract(
 
     li_start = start_line - 1
     li_end = end_line - 1
-    col_start = start_column - 1
-    col_end = end_column
+    col_start = start_column - 2
+    col_end =  end_column - 1 if start_line - end_line > 0 else end_column - 1 - col_start
 
-    # keep the ends to preserve the original string content
-    lines = file_content.splitlines(keepends=True)
+    lines = file_content.splitlines()
 
     # scope lines
     lines = [line for li, line in enumerate(lines) if li_start <= li <= li_end]


### PR DESCRIPTION
- fix counting error in column bounding markers: for some reason in gitleaks reports they're off by 1
- omit `keepends=True` when splitting lines; multiline is gonna be supported via counting (see next item)
- account for multiple lines in found secrets when calculating column-end marker, by subtracting the column-start marker if the secret spans multiple lines in the original repo